### PR TITLE
Add login and registration panel

### DIFF
--- a/logreg.html
+++ b/logreg.html
@@ -1,1 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account Access</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111c3a;
+      --accent: #38bdf8;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --error: #f87171;
+      font-size: 16px;
+    }
 
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'Inter', sans-serif;
+      background: radial-gradient(circle at top right, #1e3a8a 0%, var(--bg) 55%);
+      color: var(--text);
+      padding: 2rem;
+    }
+
+    .card {
+      width: min(960px, 100%);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 0;
+      background: rgba(17, 24, 39, 0.85);
+      border-radius: 24px;
+      overflow: hidden;
+      box-shadow: 0 35px 70px rgba(15, 23, 42, 0.55);
+      backdrop-filter: blur(12px);
+    }
+
+    .panel {
+      padding: 3rem 3.5rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      position: relative;
+    }
+
+    .panel::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(140deg, rgba(56, 189, 248, 0.15), transparent 55%);
+      opacity: 0;
+      transition: opacity 0.4s ease;
+      pointer-events: none;
+    }
+
+    .panel.active::before {
+      opacity: 1;
+    }
+
+    .panel h2 {
+      margin: 0 0 0.75rem;
+      font-size: 2rem;
+      letter-spacing: 0.5px;
+    }
+
+    .panel p {
+      margin: 0 0 2.5rem;
+      color: var(--muted);
+    }
+
+    form {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    label {
+      font-size: 0.85rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    input[type='text'],
+    input[type='email'],
+    input[type='password'] {
+      width: 100%;
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(15, 23, 42, 0.6);
+      color: var(--text);
+      font-size: 1rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    input:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .actions label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      text-transform: none;
+    }
+
+    .actions input[type='checkbox'] {
+      accent-color: var(--accent);
+      width: 1rem;
+      height: 1rem;
+    }
+
+    button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.85rem 1.75rem;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--accent), #0ea5e9);
+      color: #0f172a;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      box-shadow: 0 12px 35px rgba(56, 189, 248, 0.35);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 45px rgba(56, 189, 248, 0.45);
+    }
+
+    .ghost-button {
+      background: transparent;
+      color: var(--text);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      box-shadow: none;
+    }
+
+    .links {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .links a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .toggle {
+      padding: 3rem 3.5rem;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.3), rgba(15, 23, 42, 0.5));
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      gap: 1.5rem;
+      color: var(--muted);
+    }
+
+    .toggle h3 {
+      margin: 0;
+      font-size: 1.5rem;
+      color: var(--text);
+    }
+
+    .indicator {
+      position: absolute;
+      top: 24px;
+      right: 24px;
+      padding: 0.45rem 1rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.2);
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .message {
+      font-size: 0.85rem;
+      color: var(--error);
+      min-height: 1.2em;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 1rem;
+      }
+
+      .panel,
+      .toggle {
+        padding: 2.5rem;
+      }
+
+      .card {
+        border-radius: 18px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <section class="panel active" id="login-panel">
+      <span class="indicator">Welcome back</span>
+      <h2>Sign in to your account</h2>
+      <p>Access your personalized dashboard, continue your projects, and collaborate with your team instantly.</p>
+      <form id="login-form" novalidate>
+        <div>
+          <label for="login-email">Email</label>
+          <input type="email" id="login-email" name="email" placeholder="you@example.com" required />
+        </div>
+        <div>
+          <label for="login-password">Password</label>
+          <input type="password" id="login-password" name="password" placeholder="••••••••" required minlength="6" />
+        </div>
+        <div class="actions">
+          <label>
+            <input type="checkbox" name="remember" />
+            Remember me
+          </label>
+          <a href="#" class="links">Forgot password?</a>
+        </div>
+        <div class="message" id="login-message"></div>
+        <button type="submit">Sign In</button>
+      </form>
+      <div class="links">
+        Need an account? <a href="#" data-target="register">Create one</a>
+      </div>
+    </section>
+
+    <aside class="toggle">
+      <h3>Join the community</h3>
+      <p>Switch between login and registration to experience the full user journey. Your data isn’t saved&mdash;this is a polished concept demo.</p>
+      <button class="ghost-button" id="toggle-button">Switch to Register</button>
+    </aside>
+
+    <section class="panel" id="register-panel">
+      <span class="indicator">New here?</span>
+      <h2>Create your account</h2>
+      <p>Start your journey with a secure workspace, smart notifications, and real-time collaboration tools.</p>
+      <form id="register-form" novalidate>
+        <div>
+          <label for="register-name">Full name</label>
+          <input type="text" id="register-name" name="name" placeholder="Jane Doe" required />
+        </div>
+        <div>
+          <label for="register-email">Email</label>
+          <input type="email" id="register-email" name="email" placeholder="you@example.com" required />
+        </div>
+        <div>
+          <label for="register-password">Password</label>
+          <input type="password" id="register-password" name="password" placeholder="Create a password" required minlength="6" />
+        </div>
+        <div>
+          <label for="register-confirm">Confirm password</label>
+          <input type="password" id="register-confirm" name="confirm" placeholder="Re-enter your password" required minlength="6" />
+        </div>
+        <div class="message" id="register-message"></div>
+        <button type="submit">Sign Up</button>
+      </form>
+      <div class="links">
+        Already a member? <a href="#" data-target="login">Sign in</a>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const loginPanel = document.getElementById('login-panel');
+    const registerPanel = document.getElementById('register-panel');
+    const toggleButton = document.getElementById('toggle-button');
+    const quickLinks = document.querySelectorAll('.links a[data-target]');
+
+    const loginForm = document.getElementById('login-form');
+    const registerForm = document.getElementById('register-form');
+    const loginMessage = document.getElementById('login-message');
+    const registerMessage = document.getElementById('register-message');
+
+    const switchPanels = target => {
+      const showLogin = target === 'login';
+      loginPanel.classList.toggle('active', showLogin);
+      registerPanel.classList.toggle('active', !showLogin);
+      loginPanel.style.display = showLogin ? 'block' : 'none';
+      registerPanel.style.display = showLogin ? 'none' : 'block';
+      toggleButton.textContent = showLogin ? 'Switch to Register' : 'Switch to Login';
+      toggleButton.setAttribute('data-target', showLogin ? 'register' : 'login');
+      loginMessage.textContent = '';
+      registerMessage.textContent = '';
+    };
+
+    // initial state
+    switchPanels('login');
+
+    toggleButton.addEventListener('click', event => {
+      event.preventDefault();
+      const target = toggleButton.getAttribute('data-target') || 'register';
+      switchPanels(target);
+    });
+
+    quickLinks.forEach(link =>
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        const target = event.currentTarget.getAttribute('data-target');
+        switchPanels(target);
+      })
+    );
+
+    loginForm.addEventListener('submit', event => {
+      event.preventDefault();
+      loginMessage.textContent = '';
+      if (!loginForm.reportValidity()) {
+        loginMessage.textContent = 'Please fill in all required fields.';
+        return;
+      }
+      const email = loginForm.email.value.trim();
+      const password = loginForm.password.value;
+
+      if (!email || !password) {
+        loginMessage.textContent = 'Email and password are required.';
+        return;
+      }
+
+      loginMessage.style.color = 'var(--accent)';
+      loginMessage.textContent = 'Signed in successfully! (demo only)';
+      loginForm.reset();
+    });
+
+    registerForm.addEventListener('submit', event => {
+      event.preventDefault();
+      registerMessage.textContent = '';
+      if (!registerForm.reportValidity()) {
+        registerMessage.textContent = 'Please complete all required fields correctly.';
+        return;
+      }
+
+      const name = registerForm.name.value.trim();
+      const email = registerForm.email.value.trim();
+      const password = registerForm.password.value;
+      const confirm = registerForm.confirm.value;
+
+      if (!name || !email || !password || !confirm) {
+        registerMessage.textContent = 'All fields are required.';
+        return;
+      }
+
+      if (password !== confirm) {
+        registerMessage.textContent = 'Passwords do not match.';
+        return;
+      }
+
+      registerMessage.style.color = 'var(--accent)';
+      registerMessage.textContent = 'Account created! Sign in to continue.';
+      registerForm.reset();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a polished account access page featuring login and registration panels with responsive styling
- add interactive toggle behavior to switch between panels and provide client-side validation feedback

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf30aba8308324a2d69539ceabb7f1